### PR TITLE
Fix deprecated intersphinx_mapping dictionary use

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -181,6 +181,6 @@ texinfo_documents = [
 
 # -- Extension configuration -------------------------------------------------
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/': None),
-    'mdanalysis': ('https://docs.mdanalysis.org/stable/': None),
+    'python': ('https://docs.python.org/3/', None),
+    'mdanalysis': ('https://docs.mdanalysis.org/stable/', None),
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -181,6 +181,6 @@ texinfo_documents = [
 
 # -- Extension configuration -------------------------------------------------
 intersphinx_mapping = {
-    'https://docs.python.org/3/': None,
-    'https://docs.mdanalysis.org/stable/': None,
+    'python': ('https://docs.python.org/3/': None),
+    'mdanalysis': ('https://docs.mdanalysis.org/stable/': None),
 }


### PR DESCRIPTION
Current intersphinx_mapping use is deprecated, this switches to the new dict of tuples approach.