### PR TITLE
update maintainers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 [build-system]
 requires = [
   "setuptools >= 40.9.0",
@@ -12,10 +14,15 @@ name = "mdaencore"
 description = "Ensemble overlap comparison software for molecular data."
 license = {file = "LICENSE" }
 authors = [
-    {name = "MDAnalysis", email = "mdanalysis@numfocus.org"},
+    {name = "Matteo Tiberti", email = "tiberti@cancer.dk"},
+    {name = "Wouter Boomsma", email = "wb@di.ku.dk"},    
+    {name = "Tone Bengtsen", email = "tonebengsten@gmail.com"},
+    {name = "Ian M. Kenney", email = "ikenney@asu.edu"},
+    {name = "mdaencore AUTHORS"},
 ]
 maintainers = [
-    {name = "MDAnalysis", email = "mdanalysis@numfocus.org"},
+    {name = "Kristoffer Enøe Johansson", email = "kristoffer.johansson@bio.ku.dk"},
+    {name = "Kresten Lindorff-Larsen", email = "lindorff@bio.ku.dk"},
 ]
 readme = "README.md"
 requires-python = ">=3.9"
@@ -40,9 +47,9 @@ doc = [
     "mdanalysis_sphinx_theme",
 ]
 
-# [project.urls]
-# source = "https://github.com/MDAnalysis/mdaencore"
-# documentation = "https://mdaencore.readthedocs.io"
+[project.urls]
+source = "https://github.com/MDAnalysis/mdaencore"
+documentation = "https://www.mdanalysis.org/mdaencore/"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 mdaencore
 Ensemble overlap comparison software for molecular data.
@@ -99,8 +100,8 @@ exts, cythonfiles = extensions()
 setup(
     # Self-descriptive entries which should always be present
     name='mdaencore',
-    author='MDAnalysis',
-    author_email='mdanalysis@numfocus.org',
+    author='Kristoffer Enøe Johansson and AUTHORS',
+    author_email='kristoffer.johansson@bio.ku.dk',
     description=short_description,
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #47 (partially)

Changes made in this Pull Request:

- part of #47
- add new maintainers in pyproject.toml
- updated author list in pyproject.toml: explicitly list the original
  ENCORE authors and Ian (for his work in porting mdaencore), list everyone
  else implicitly as "mdaencore AUTHORS"
- changed maintainer to @enoee
- updated author in setup.py to be the maintainer + AUTHORs but uses
  @enoee s email; as far as I can tell, the PyPi page will use the better
  metadata from pyproject.toml so it should be fine

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [x] Issue raised/referenced?
