### PR TITLE
Bump up the PyPi upload version

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -118,7 +118,7 @@ jobs:
           path: dist
 
       - name: upload_source_and_wheels
-        uses: pypa/gh-action-pypi-publish@v1.5.0
+        uses: pypa/gh-action-pypi-publish@v1.8.10
 
   check_testpypi:
     if: |


### PR DESCRIPTION
Looks like we forgot to update the one version number.