### PR TITLE
Encore Windows type fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,14 @@ The rules for this file:
 
 ### Authors
 - ianmkenney
+- tylerjereddy
 
 ### Added
 <!-- Added functionality -->
 
 ### Fixed
 - All dependencies added to pyproject.toml, setup.py, and conda envs (#57)
+- Temporary fix for Windows integer size default change in NumPy 2.0.0
 
 ### Changed
 <!-- Changes in existing functionality -->

--- a/mdaencore/clustering/affinityprop.pyx
+++ b/mdaencore/clustering/affinityprop.pyx
@@ -96,7 +96,7 @@ def AffinityPropagation(s, preference, float lam, int max_iterations, int conver
 
     # Prepare input and ouput arrays
     cdef numpy.ndarray[numpy.float32_t,  ndim=1] matndarray = numpy.ascontiguousarray(s._elements, dtype=numpy.float32)
-    cdef numpy.ndarray[long,   ndim=1] clusters   = numpy.zeros((s.size),dtype=long)
+    cdef numpy.ndarray[long,   ndim=1] clusters   = numpy.zeros((s.size),dtype=numpy.dtype("long"))
 
     # run C module Affinity Propagation
     iterations = CAffinityPropagation(<float*>matndarray.data, cn, lam, max_iterations, convergence, noise, <long*>clusters.data)


### PR DESCRIPTION
Original commit message by @tylerjereddy:

* in NumPy `2.0.0`, the default integer size on Windows will be 64-bit; we have 10 related test failures on Windows alongside NumPy `main` at the moment, and this patch fixes those failures by forcing a reversion to the old behavior, effectively kicking the can down the road

* I think we're going to proceed with a similar solution upstream for now (i.e., scipy/scipy#19605 (comment));

Fixes #59 


PR Checklist
------------
 - [x] Tests?
 - [x] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
