### PR TITLE
Remove x86_64 env build pin

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -58,7 +58,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml
         add-pip-as-python-dependency: true
-        architecture: x64
 
         miniforge-variant: Mambaforge
         use-mamba: true


### PR DESCRIPTION
See: https://github.com/MDAnalysis/cookiecutter-mdakit/pull/134


<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - 
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
