### PR TITLE
Switch from mambaforge to miniforge in tests

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -58,16 +58,13 @@ jobs:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml
         add-pip-as-python-dependency: true
-
-        miniforge-variant: Mambaforge
+        miniforge-version: latest
         use-mamba: true
         channels: conda-forge, defaults
-
         activate-environment: mdaencore-test
         auto-update-conda: true
         auto-activate-base: false
         show-channel-urls: true
-
 
     - name: Install MDAnalysis version
       uses: MDAnalysis/install-mdanalysis@main


### PR DESCRIPTION
Mambaforge is deprecated in favour of miniforge (it's actually just the same thing but a rename).