### PR TITLE
updated Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,136 +1,89 @@
-# Code of conduct
-
-The mdaencore *Code of Conduct* sets the rules for the behavior of
-every member in the mdaencore community so that everyone can
+The MDAnalysis *Code of Conduct* sets the rules for the behavior of
+every member in the MDAnalysis community so that everyone can
 experience a welcoming, supportive, and productive environment that is
-free from harassment.
+free from harassment. As a [NumFOCUS][NF] sponsored
+project, MDAnalysis follows the [NumFOCUS Code of Conduct][NF-conduct].
 
-<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-generate-toc again -->
 **Table of Contents**
 
-- [Code of conduct](#code-of-conduct)
-  - [Code of Conduct and Community Guidelines](#code-of-conduct-and-community-guidelines)
-  - [Scope](#scope)
-  - [Enforcement](#enforcement)
-  - [Acknowledgment](#acknowledgment)
+- [MDAnalysis Code of Conduct](#numfocus-code-of-conduct)
+- [How to Report](#how-to-report)
+- [Who Will Receive Your Report](#who-will-receive-your-report)
+- [Diversity, Equity, and Inclusion Statement](#diversity-equity-and-inclusion-statement)
+- [Acknowledgment](#acknowledgment)
 
-<!-- markdown-toc end -->
-## Code of Conduct and Community Guidelines
+## MDANALYSIS CODE OF CONDUCT
+You can find the whole document here: [https://numfocus.org/code-of-conduct][NF-conduct].
 
-mdaencore is part of an engaged and respectful community made up of people from all
-over the world. Your involvement helps us to further our mission and to create
-an open platform that serves a broad range of communities, from research and
-education to industry and beyond. This diversity is one of our biggest
-strengths, but it can also lead to communication issues and conflicts.
-Therefore, we have a few ground rules we ask that our community members adhere
-to.
+### THE SHORT VERSION
+MDAnalysis and NumFOCUS are dedicated to providing a harassment-free community for everyone,
+regardless of gender, sexual orientation, gender identity and expression, disability,
+physical appearance, body size, race, or religion. We do not tolerate harassment of
+community members in any form.
 
-Fundamentally, we are committed to providing a productive,
-harassment-free environment for everyone. Rather than considering this
-code an exhaustive list of things that you can’t do, take it in the
-spirit it is intended - a guide to make it easier to enrich all of us
-and the communities in which we participate.
+Be kind to others. Do not insult or put down others. Behave professionally. Remember
+that harassment and sexist, racist, or exclusionary jokes are not appropriate for MDAnalysis
+or NumFOCUS.
 
-Importantly: as a member of our community, you are also a steward of these
-values. Not all problems need to be resolved via formal processes, and often a
-quick, friendly but clear word on an online forum or in person can help resolve
-a misunderstanding and de-escalate things.
+All communication should be appropriate for a professional audience including people of
+many different backgrounds. Sexual language and imagery is not appropriate.
 
-By embracing the following principles, guidelines and actions to follow or
-avoid, you will help us make mdaencore a welcoming and productive community.
+Thank you for helping make this a welcoming, friendly community for all.
 
-1. **Be friendly and patient**.
+### THE LONG VERSION
+You can find the long version of the Code of Conduct on the NumFOCUS website:
+[https://numfocus.org/code-of-conduct][NF-conduct].
 
-2. **Be welcoming**. We strive to be a community that welcomes and supports
-   people of all backgrounds and identities. This includes, but is not limited
-   to, members of any race, ethnicity, culture, national origin, color,
-   immigration status, social and economic class, educational level, sex, sexual
-   orientation, gender identity and expression, age, physical appearance, family
-   status, political belief, technological or professional choices, academic
-   discipline, religion, mental ability, and physical ability.
+## HOW TO REPORT
+If you feel that the Code of Conduct has been violated, feel free to submit a report, by
+using the [NumFOCUS Code of Conduct Reporting Form](https://numfocus.typeform.com/to/ynjGdT?typeform-source=numfocus.org).
 
-3. **Be considerate**. Your work will be used by other people, and you in turn
-   will depend on the work of others. Any decision you take will affect users
-   and colleagues, and you should take those consequences into account when
-   making decisions. Remember that we're a world-wide community. You may be
-   communicating with someone with a different primary language or cultural
-   background.
+### REPORTING AT MDANALYSIS EVENTS AND MEETUPS
+If you are attending an MDAnalysis event or meetup and wish to make a report that requires
+an appropriate immediate response, you may contact the ombudspersons (who will identify
+themselves at the event) or other event staff/meetup organizers. If you would prefer not to
+do that, please [submit a report](#how-to-report) to NumFOCUS, but please note it may not be
+possible for the [NumFOCUS Code of Conduct Working Group](#who-will-receive-your-report) to
+respond immediately. 
 
-4. **Be respectful**. Not all of us will agree all the time, but disagreement is
-   no excuse for poor behavior or poor manners. We might all experience some
-   frustration now and then, but we cannot allow that frustration to turn into a
-   personal attack. It’s important to remember that a community where people
-   feel uncomfortable or threatened is not a productive one.
+Ombudspeople and event staff/meetup organizers will be happy to help participants contact
+venue security or local law enforcement, provide escorts, or otherwise assist those
+experiencing harassment to feel safe for the duration of the event/meetup.
 
-5. **Be careful in the words that you choose**. Be kind to others. Do not insult
-   or put down other community members. Harassment and other exclusionary
-   behavior are not acceptable. This includes, but is not limited to:
-   * threats or violent language directed against another person
-   * discriminatory jokes and language
-   * posting sexually explicit or violent material
-   * posting (or threatening to post) other people's personally identifying
-     information ("doxing")
-   * personal insults, especially those using racist or sexist terms
-   * unwelcome sexual attention
-   * advocating for, or encouraging, any of the above behavior
-   * repeated harassment of others. In general, if someone asks you to stop,
-     then stop
+## WHO WILL RECEIVE YOUR REPORT
+Your report will be received and handled by the NumFOCUS Code of Conduct Working Group; trained,
+and experienced contributors with diverse backgrounds. The group is making decisions independently
+from the MDAnalysis project, PyData, NumFOCUS or any other organization. 
 
-6. **Moderate your expectations**. Many in our community volunteer their time.
-   They are probably not purposefully ignoring issues, refusing to engage in
-   discussion, avoiding features, etc. but often just unavailable.
+You can learn more about the current group members, as well as the reporting procedure [HERE][NF-conduct].
 
-7. **When we disagree, try to understand why**. Disagreements, both social and
-   technical, happen all the time and mdaencore is no exception. It is important
-   that we resolve disagreements and differing views constructively. Remember
-   that we’re different. The strength of mdaencore comes from its varied community
-   that includes people from a wide range of backgrounds. Different people have
-   different perspectives on issues. Being unable to understand why someone
-   holds a viewpoint doesn’t mean they’re wrong. Don’t forget that it is human
-   to err and blaming each other doesn’t get us anywhere. Instead, focus on
-   helping to resolve issues and learning from mistakes.
+### ENFORCEMENT
+Based on recommendations for next steps as determined by the NumFOCUS Code of Conduct Working Group,
+the MDAnalysis project will remain responsible for making the final decision and implementing any
+resulting actions. See the [MDAnalysis team](https://www.mdanalysis.org/pages/team/#roles) page on
+the MDAnalysis website for a current list of the **MDAnalysis Code of Conduct Committee** members.
 
-8. **A simple apology can go a long way**. It can often de-escalate a situation,
-   and telling someone that you are sorry is act of empathy that doesn’t
-   automatically imply an admission of guilt.
+Once a resolution has been agreed upon, but before it is enacted, the MDAnalysis Code of Conduct
+Committee will contact the original reporter and any other affected parties and explain the proposed
+resolution. We will ask if this resolution is acceptable and note feedback for the record. We are,
+however, not required to act on this feedback.
 
+## DIVERSITY, EQUITY, AND INCLUSION STATEMENT
+MDAnalysis strives to ensure a welcoming, inclusive space for all. As a [NumFOCUS][NF] sponsored project,
+we fully support their [*Diversity & Inclusion in Scientific Computing*](https://numfocus.org/programs/diversity-inclusion)
+(DISC) mission and abide by their Diversity Statement:
 
-## Scope
+> *"NumFOCUS welcomes and encourages participation in our community by people of all backgrounds and identities.
+> We are committed to promoting and sustaining a culture that values mutual respect, tolerance, and learning,
+> and we work together as a community to help each other live out these values."*
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an
-appointed representative at an online or offline event. Representation of a
-project may be further defined and clarified by project maintainers.
+## ACKNOWLEDGMENT
 
-## Enforcement
+Original text courtesy of [*NumFOCUS*](https://numfocus.org/code-of-conduct), modified by MDAnalysis.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at 'mdanalysis@numfocus.org'. The project team will
-review and investigate all complaints, and will respond in a way that it deems
-appropriate to the circumstances. The project team is obligated to maintain
-confidentiality with regard to the reporter of an incident. Further details of
-specific enforcement policies may be posted separately.
+All content on this page is licensed under a [*Creative Commons Attribution*](http://creativecommons.org/licenses/by/3.0/)
+license. 
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+[NF]: https://numfocus.org/
+[NF-conduct]: https://numfocus.org/code-of-conduct
 
-
-## Acknowledgment
-
-Original text was adapted from
-the
-[*Speak Up!*](http://web.archive.org/web/20141109123859/http://speakup.io/coc.html),
-[*Django*](https://www.djangoproject.com/conduct),
-[*Contributor Covenant*](http://contributor-covenant.org/),
-[*Jupyter*](https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md),
-[*MolSSI*](https://github.com/MolSSI/cookiecutter-cms/blob/master/%7B%7Bcookiecutter.repo_name%7D%7D/CODE_OF_CONDUCT.md),
-and [*MDAnalysis*](https://github.com/MDAnalysis/mdanalysis/blob/develop/CODE_OF_CONDUCT.md) projects,
-modified by mdaencore.
-We are grateful to those projects for contributing these
-materials under open licensing terms for us to easily reuse.
-
-All content on this page is licensed under a [*Creative Commons
-Attribution*](http://creativecommons.org/licenses/by/3.0/) license. 


### PR DESCRIPTION
Fixes #73

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
- fix #73
- MDAnalysis Org adapted NF Code of Conduct in 2025 and it applies to ALL projects in the org, thus the encore CoC needed to be replaced with the new official one



PR Checklist
------------
 - n/a Tests?
 - n/a Docs?
 - n/a CHANGELOG updated?
 - [x] Issue raised/referenced?
